### PR TITLE
Update strip_comments example to work correctly in Python 3

### DIFF
--- a/strip_all_comments.py
+++ b/strip_all_comments.py
@@ -8,10 +8,10 @@ from octoprint.util.comm import strip_comment
 
 class CommentStripper(octoprint.filemanager.util.LineProcessorStream):
 	def process_line(self, line):
-		line = strip_comment(line).strip()
-		if not len(line):
+		decoded_line = strip_comment(line.decode()).strip()
+		if not len(decoded_line):
 			return None
-		return line + "\r\n"
+		return (decoded_line + "\r\n").encode()
 
 def strip_all_comments(path, file_object, links=None, printer_profile=None, allow_overwrite=True, *args, **kwargs):
 	if not octoprint.filemanager.valid_file_type(path, type="gcode"):
@@ -27,7 +27,7 @@ def strip_all_comments(path, file_object, links=None, printer_profile=None, allo
 __plugin_name__ = "Strip comments from GCODE"
 __plugin_description__ = "Strips all comments and empty lines from uploaded/generated GCODE files ending on the name " \
                          "postfix \"_strip\", e.g. \"some_file_strip.gcode\"."
-__plugin_pythoncompat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">=3,<4"
 __plugin_hooks__ = {
 	"octoprint.filemanager.preprocessor": strip_all_comments
 }


### PR DESCRIPTION
Update strip_comments example to work correctly with the bytes vs. str mismatch where octoprint.util.comm.strip_comments function and the octoprint.filemanager.util.LineProcessorStream api mismatch